### PR TITLE
Fix transaction support

### DIFF
--- a/camus.py
+++ b/camus.py
@@ -216,7 +216,7 @@ class Database:
 
         try:
             yield self._transactionId
-            tx.commit()
+            aurora.commit_transaction(**self._auth(), transactionId=self._transactionId)
         except:
             aurora.rollback_transaction(**self._auth(), transactionId=tx['transactionId'])
         finally:


### PR DESCRIPTION
The `commit` command was being called from the wrong object and it was raising an exception but because it was inside a **try-except** block the error message got suppressed and the `rollback` command ended up by reverting all the changes in the database.